### PR TITLE
fix: add better error logging for Plus quality Mux videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install @mux/mux-background-video
 ## Usage
 
 > [!IMPORTANT]
-> Requires Mux [Basic](https://www.mux.com/docs/guides/use-video-quality-levels#basic) or [Premium](https://www.mux.com/docs/guides/use-video-quality-levels#premium) video quality currently because transmuxing of `.ts` segments is not supported.
+> Requires Mux [Basic](https://www.mux.com/docs/guides/use-video-quality-levels#basic) or [Premium](https://www.mux.com/docs/guides/use-video-quality-levels#premium) video quality. The [Plus](https://www.mux.com/docs/guides/use-video-quality-levels#plus) tier (and other classic HLS sources) is **not** supported because it serves MPEG-TS (`.ts`) segments, which this engine does not transmux.
 
 ### HTMLCustom Element
 

--- a/src/engines/hls-mini/mediasource.ts
+++ b/src/engines/hls-mini/mediasource.ts
@@ -41,8 +41,11 @@ export const loadMedia = (
       initLoadSegments(mediaPlaylists, mediaSource, mediaEl, config, signal);
     })
     .catch((error) => {
-      if (error === 'unload') return;
-      throw error;
+      if (error === 'unload' || signal.aborted) return;
+      // Surface the failure instead of re-throwing as an unhandled rejection.
+      // The load loop is never started when this fires, so there is no
+      // infinite retry to stop — this is purely about visibility.
+      console.error('[mux-background-video] failed to load source:', error);
     });
 
   return unload;
@@ -117,7 +120,7 @@ const initLoadSegments = (
   signal: AbortSignal
 ) => {
   let isLoading = false;
-  let checkInterval: NodeJS.Timeout;
+  let checkInterval: ReturnType<typeof setInterval>;
   let initSegments = getInitSegments(mediaPlaylists);
 
   const loadNextSegments = async () => {

--- a/src/engines/hls-mini/playlists.ts
+++ b/src/engines/hls-mini/playlists.ts
@@ -130,27 +130,31 @@ export const getMediaPlaylist = async <T extends Rendition>(
   return { ...mediaPlaylistData, segments };
 };
 
-// This engine only supports fMP4 (CMAF) segments. MPEG-TS playlists, served by
-// Mux's Plus tier and other classic HLS sources, lack an `#EXT-X-MAP` init
-// segment and use `.ts` segment URIs. Bail out early with a typed error rather
-// than letting MSE silently reject the appended bytes.
+// This engine only supports fMP4 (CMAF) segments, which always include an
+// `#EXT-X-MAP` init segment. MPEG-TS playlists (Mux Plus tier, classic HLS)
+// lack that init segment. Bail out early with a clear error rather than
+// letting MSE silently reject the appended bytes.
 const assertFmp4Segments = (segments: Segment[]) => {
   if (segments.length === 0) return;
   const hasInitSegment = segments.some((s) => (s.duration || 0) === 0 && !!s.uri);
   if (hasInitSegment) return;
 
-  const firstMediaSegment = segments.find((s) => (s.duration || 0) > 0 && !!s.uri);
-  const uri = firstMediaSegment?.uri ?? '';
-  const looksLikeMpegTs = /\.ts(\?|$)/i.test(new URL(uri).pathname);
-
-  if (looksLikeMpegTs || !hasInitSegment) {
-    throw new Error(
-      'Unsupported HLS segment format: this engine requires fMP4 (CMAF) segments ' +
-      'but the playlist contains MPEG-TS (.ts) segments. For Mux streams, use ' +
-      'Basic or Premium video quality. See ' +
-      'https://www.mux.com/docs/guides/use-video-quality-levels'
-    );
+  // No init segment → not fMP4. Check URIs to give a more specific message.
+  const firstUri = segments.find((s) => !!s.uri)?.uri;
+  let hint = '';
+  try {
+    if (firstUri && /\.ts(\?|$)/i.test(new URL(firstUri).pathname)) {
+      hint = ' (MPEG-TS .ts segments detected)';
+    }
+  } catch {
+    // URL parsing failed — not critical, leave hint empty.
   }
+
+  throw new Error(
+    `Unsupported HLS segment format${hint}: this engine requires fMP4 (CMAF) ` +
+    'segments with an #EXT-X-MAP init segment. For Mux streams, use Basic or ' +
+    'Premium video quality. See https://www.mux.com/docs/guides/use-video-quality-levels'
+  );
 };
 
 const addSegmentStartAndEndTimes = (segments: Segment[]) => {

--- a/src/engines/hls-mini/playlists.ts
+++ b/src/engines/hls-mini/playlists.ts
@@ -130,31 +130,15 @@ export const getMediaPlaylist = async <T extends Rendition>(
   return { ...mediaPlaylistData, segments };
 };
 
-// This engine only supports fMP4 (CMAF) segments, which always include an
-// `#EXT-X-MAP` init segment. MPEG-TS playlists (Mux Plus tier, classic HLS)
-// lack that init segment. Bail out early with a clear error rather than
-// letting MSE silently reject the appended bytes.
+// Reject non-fMP4 playlists (e.g. MPEG-TS from Mux Plus) that would
+// silently fail at appendBuffer time. fMP4 always has an init segment.
 const assertFmp4Segments = (segments: Segment[]) => {
-  if (segments.length === 0) return;
-  const hasInitSegment = segments.some((s) => (s.duration || 0) === 0 && !!s.uri);
-  if (hasInitSegment) return;
-
-  // No init segment → not fMP4. Check URIs to give a more specific message.
-  const firstUri = segments.find((s) => !!s.uri)?.uri;
-  let hint = '';
-  try {
-    if (firstUri && /\.ts(\?|$)/i.test(new URL(firstUri).pathname)) {
-      hint = ' (MPEG-TS .ts segments detected)';
-    }
-  } catch {
-    // URL parsing failed — not critical, leave hint empty.
+  if (segments.length > 0 && !segments.some((s) => !s.duration && s.uri)) {
+    throw new Error(
+      'Unsupported segment format: fMP4 required. ' +
+      'https://www.mux.com/docs/guides/use-video-quality-levels'
+    );
   }
-
-  throw new Error(
-    `Unsupported HLS segment format${hint}: this engine requires fMP4 (CMAF) ` +
-    'segments with an #EXT-X-MAP init segment. For Mux streams, use Basic or ' +
-    'Premium video quality. See https://www.mux.com/docs/guides/use-video-quality-levels'
-  );
 };
 
 const addSegmentStartAndEndTimes = (segments: Segment[]) => {

--- a/src/engines/hls-mini/playlists.ts
+++ b/src/engines/hls-mini/playlists.ts
@@ -126,7 +126,31 @@ export const getMediaPlaylist = async <T extends Rendition>(
   const segments = addSegmentStartAndEndTimes(
     await getPlaylistFromURI(mediaPlaylistData.uri, MediaPlaylistReducerTuples, signal)
   );
+  assertFmp4Segments(segments);
   return { ...mediaPlaylistData, segments };
+};
+
+// This engine only supports fMP4 (CMAF) segments. MPEG-TS playlists, served by
+// Mux's Plus tier and other classic HLS sources, lack an `#EXT-X-MAP` init
+// segment and use `.ts` segment URIs. Bail out early with a typed error rather
+// than letting MSE silently reject the appended bytes.
+const assertFmp4Segments = (segments: Segment[]) => {
+  if (segments.length === 0) return;
+  const hasInitSegment = segments.some((s) => (s.duration || 0) === 0 && !!s.uri);
+  if (hasInitSegment) return;
+
+  const firstMediaSegment = segments.find((s) => (s.duration || 0) > 0 && !!s.uri);
+  const uri = firstMediaSegment?.uri ?? '';
+  const looksLikeMpegTs = /\.ts(\?|$)/i.test(new URL(uri).pathname);
+
+  if (looksLikeMpegTs || !hasInitSegment) {
+    throw new Error(
+      'Unsupported HLS segment format: this engine requires fMP4 (CMAF) segments ' +
+      'but the playlist contains MPEG-TS (.ts) segments. For Mux streams, use ' +
+      'Basic or Premium video quality. See ' +
+      'https://www.mux.com/docs/guides/use-video-quality-levels'
+    );
+  }
 };
 
 const addSegmentStartAndEndTimes = (segments: Segment[]) => {


### PR DESCRIPTION
Closes #34 

Added better error logging for TS segments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces stricter playlist validation that can cause previously attempted streams to fail earlier, so compatibility depends on the init-segment heuristic being correct; otherwise changes are limited to logging/error handling.
> 
> **Overview**
> Improves failure visibility when loading HLS sources by logging top-level `loadMedia` failures (instead of rethrowing as an unhandled rejection) and ignoring errors triggered by abort/unload.
> 
> Adds an explicit guard in `getMediaPlaylist` to reject non-fMP4 media playlists (missing an init segment), producing a clear error that points to Mux quality tier docs; the README is updated to clearly state that Mux Plus/classic HLS (`.ts` segments) is not supported. Also tweaks the interval timer typing in `mediasource.ts` for broader TS compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a429575bcf425118730f2898eb65cdc5a285f90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->